### PR TITLE
[vusb] Fix so xenbus remove will not try to delete the usbif device t…

### DIFF
--- a/xc-vusb/xc-vusb.c
+++ b/xc-vusb/xc-vusb.c
@@ -2709,6 +2709,10 @@ vusb_xenusb_remove(struct xenbus_device *dev)
 {
 	struct vusb_device *vdev = dev_get_drvdata(&dev->dev);
 
+	/* Did something else already destroy the vusb device? */
+	if (!vdev)
+		return 0;
+
 	iprintk("xen_usbif remove %s\n", dev->nodename);
 
 	vusb_destroy_device(vdev);


### PR DESCRIPTION
…wice.

It is possible for the usbif device to be deleted in the backend changed
routine. Then the xenbus remove routine can be called. The fix tests to see
if the usbif device was already deleted.

OXT-328

Signed-off-by: Ross Philipson philipsonr@ainfosec.com
