### PR TITLE
xc-vusb: add support for a second backend, to be used for virtual HID devices

### DIFF
--- a/xc-vusb/xc-vusb.c
+++ b/xc-vusb/xc-vusb.c
@@ -2829,6 +2829,7 @@ vusb_usbfront_resume(struct xenbus_device *dev)
 
 static struct xenbus_device_id vusb_usbfront_ids[] = {
 	{ "vusb" },
+	{ "vhid" },
 	{ "" }
 };
 


### PR DESCRIPTION
This won't change anything, but will enable implementing a second USB backend.
This is needed for SuperHID, but could be used by any USB HID backend.

Signed-off-by: Jed lejosnej@ainfosec.com
