### PR TITLE
STABLE-6: OXT-326: get_unused_fd{,_flags}() depending on Linux kernel versions.

### DIFF
--- a/openxt-v4v/openxt-v4v.c
+++ b/openxt-v4v/openxt-v4v.c
@@ -2835,7 +2835,11 @@ allocate_fd_with_private (void *private)
   struct inode *ind;
 #endif
 
-  fd = get_unused_fd ();
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(3,7,0))
+  fd = get_unused_fd();
+#else
+  fd = get_unused_fd_flags(O_CLOEXEC);
+#endif
   if (fd < 0)
     return fd;
 


### PR DESCRIPTION
Replace get_unused_fd() with get_unused_fd_flags() when introduced in
kernels >=3.7.x. Also enforce O_CLOEXEC flags as it is very unlikely to
introduce any drawback, but could avoid some fd leak.

Also sync with v4v.git regarding this topic.

OXT-326

(cherry picked from commit 44658ceb739ab0fc2f0e67fcb171e8b186a0f411)
