### PR TITLE
OXT-791: Compilation against various kernel version

### DIFF
--- a/openxt-v4v/include/xen/hypercall6.h
+++ b/openxt-v4v/include/xen/hypercall6.h
@@ -29,6 +29,7 @@
 #endif
 
 #undef __HYPERCALL_DECLS
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,6,0)
 #define __HYPERCALL_DECLS						\
 	register unsigned long __res  asm(__HYPERCALL_RETREG);		\
 	register unsigned long __arg1 asm(__HYPERCALL_ARG1REG) = __arg1; \
@@ -37,6 +38,17 @@
 	register unsigned long __arg4 asm(__HYPERCALL_ARG4REG) = __arg4; \
 	register unsigned long __arg5 asm(__HYPERCALL_ARG5REG) = __arg5; \
 	register unsigned long __arg6 asm(__HYPERCALL_ARG6REG) = __arg6;
+#else
+#define __HYPERCALL_DECLS						\
+	register unsigned long __res  asm(__HYPERCALL_RETREG);		\
+	register unsigned long __arg1 asm(__HYPERCALL_ARG1REG) = __arg1; \
+	register unsigned long __arg2 asm(__HYPERCALL_ARG2REG) = __arg2; \
+	register unsigned long __arg3 asm(__HYPERCALL_ARG3REG) = __arg3; \
+	register unsigned long __arg4 asm(__HYPERCALL_ARG4REG) = __arg4; \
+	register unsigned long __arg5 asm(__HYPERCALL_ARG5REG) = __arg5; \
+	register unsigned long __arg6 asm(__HYPERCALL_ARG6REG) = __arg6; \
+	register void *__sp asm(_ASM_SP);
+#endif
 
 #undef __HYPERCALL_CLOBBER5
 

--- a/openxt-xenmou/xenmou.c
+++ b/openxt-xenmou/xenmou.c
@@ -159,8 +159,6 @@ static void destroy_device (struct XenMou_DriverInfo *dr, int slot);
 static int xenmou_thread_fn (void *data);
 
 
-MODULE_DEVICE_TABLE (pci, xenmou_pci_tbl);
-
 static const struct pci_device_id xenmou_pci_tbl[]
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3,8,0))
 __devinitdata
@@ -169,6 +167,7 @@ __devinitdata
     {PCI_DEVICE (XENMOU_VENDOR, XENMOU_ID)},
     {0,}                        /* 0 terminated list. */
 };
+MODULE_DEVICE_TABLE (pci, xenmou_pci_tbl);
 
 static int suspend (struct pci_dev *dev, pm_message_t state)
 {
@@ -463,7 +462,7 @@ int xenmou_init_one (struct pci_dev *dev, const struct pci_device_id *id)
         goto exit;
     }
 
-    ret = request_irq (dev->irq, irq_handler, IRQF_SHARED | IRQF_DISABLED, XENMOU_NAME, &DriverInfo);
+    ret = request_irq (dev->irq, irq_handler, IRQF_SHARED, XENMOU_NAME, &DriverInfo);
 
     iowrite32(0x3, &DriverInfo.control->control);
     printk (KERN_INFO "XenMou (v%d) inishalised ok. OS = %d\n", rev, hostos);


### PR DESCRIPTION
Fix a couple of compilation warnings/errors due to changes in API used for OpenXT drivers.
- v4v: We should really not touch HYPERCALL_DECLS and remove hypercall6 altogether. This is TBD already with coming V4V work (and also covers repository duplication).
- vusb: xenbus_grant_ring() now supports multiple page rings.
- xenmou: Use deprecated macro constant.

OXT-791
