### PR TITLE
OXT-964: Fix compilation on kernel>4.6

### DIFF
--- a/openxt-v4v/Kbuild
+++ b/openxt-v4v/Kbuild
@@ -1,1 +1,2 @@
+ccflags-y = -I$(src)/include
 obj-m += openxt-v4v.o 

--- a/openxt-v4v/include/xen/hypercall6.h
+++ b/openxt-v4v/include/xen/hypercall6.h
@@ -29,6 +29,7 @@
 #endif
 
 #undef __HYPERCALL_DECLS
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,6,0)
 #define __HYPERCALL_DECLS						\
 	register unsigned long __res  asm(__HYPERCALL_RETREG);		\
 	register unsigned long __arg1 asm(__HYPERCALL_ARG1REG) = __arg1; \
@@ -37,6 +38,17 @@
 	register unsigned long __arg4 asm(__HYPERCALL_ARG4REG) = __arg4; \
 	register unsigned long __arg5 asm(__HYPERCALL_ARG5REG) = __arg5; \
 	register unsigned long __arg6 asm(__HYPERCALL_ARG6REG) = __arg6;
+#else
+#define __HYPERCALL_DECLS						\
+	register unsigned long __res  asm(__HYPERCALL_RETREG);		\
+	register unsigned long __arg1 asm(__HYPERCALL_ARG1REG) = __arg1; \
+	register unsigned long __arg2 asm(__HYPERCALL_ARG2REG) = __arg2; \
+	register unsigned long __arg3 asm(__HYPERCALL_ARG3REG) = __arg3; \
+	register unsigned long __arg4 asm(__HYPERCALL_ARG4REG) = __arg4; \
+	register unsigned long __arg5 asm(__HYPERCALL_ARG5REG) = __arg5; \
+	register unsigned long __arg6 asm(__HYPERCALL_ARG6REG) = __arg6; \
+        register void *__sp asm(_ASM_SP);
+#endif
 
 #undef __HYPERCALL_CLOBBER5
 

--- a/openxt-v4v/openxt-v4v.c
+++ b/openxt-v4v/openxt-v4v.c
@@ -2835,7 +2835,11 @@ allocate_fd_with_private (void *private)
   struct inode *ind;
 #endif
 
-  fd = get_unused_fd ();
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(3,7,0))
+  fd = get_unused_fd();
+#else
+  fd = get_unused_fd_flags(O_CLOEXEC);
+#endif
   if (fd < 0)
     return fd;
 


### PR DESCRIPTION
Fix compilation for tools on Ubuntu 16.04 and 16.10.