### PR TITLE
vusb: Avoid 100% CPU suspending & resuming

### DIFF
--- a/openxt-vusb/openxt-vusb.c
+++ b/openxt-vusb/openxt-vusb.c
@@ -827,7 +827,6 @@ vusb_hcd_hub_status(struct usb_hcd *hcd, char *buf)
 {
 	struct vusb_vhcd *vhcd = hcd_to_vhcd(hcd);
 	unsigned long flags;
-	int resume = 0;
 	int changed = 0;
 	u16 length = 0;
 	int ret = 0;
@@ -868,12 +867,9 @@ vusb_hcd_hub_status(struct usb_hcd *hcd, char *buf)
 					vport->port, vport->port_status);
 			changed = 1;
 		}
-
-		if (vport->port_status & USB_PORT_STAT_CONNECTION)
-			resume = 1;
 	}
 
-	if (resume && vhcd->rh_state == VUSB_RH_SUSPENDED)
+	if (vhcd->rh_state == VUSB_RH_SUSPENDED && changed)
 		usb_hcd_resume_root_hub(hcd);
 
 	ret = (changed) ? length : 0;


### PR DESCRIPTION
On device unplug, I'm seeing the driver go into a tight loop of non-stop
suspending and resuming.

openxt-vusb is continuously calling usb_hcd_resume_root_hub.  The code
is very similar to usbip/vhci_hcd.c:vhci_hub_status(), but vhci doesn't
have that extra USB_PORT_STAT_CONNECTION check.  That check is basically
on device presence and not device change (USB_PORT_STAT_C_CONNECTION)
which is in the PORT_C_MASK.

Modify vusb_hcd_hub_status to remove the "resume" condition and trigger
usb_hcd_resume_root_hub only on change.  This seems to work and avoid
the looping.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>