### PR TITLE
vusb: Fix gnttab_end_foreign_access call

### DIFF
--- a/openxt-vusb/openxt-vusb.c
+++ b/openxt-vusb/openxt-vusb.c
@@ -2355,7 +2355,7 @@ vusb_usbif_free(struct vusb_device *vdev)
 		xenbus_teardown_ring((void **)&vdev->ring.sring, 1,
 				     &vdev->ring_ref);
 #else
-		gnttab_end_foreign_access(vdev->ring_ref, 0,
+		gnttab_end_foreign_access(vdev->ring_ref,
 					(unsigned long)vdev->ring.sring);
 #endif
 		vdev->ring_ref = GRANTREF_INVALID;


### PR DESCRIPTION
The gnttab_end_foreign_access() call in vusb_usbif_free() still has 3 arguments, but it should only be 2.  The enclosing #if hid it.  Correct it now.

Fixes: 64b3e77b0db5 ("Add gnttab_end_foreign_access wrapper")